### PR TITLE
adds Jira integration and area-based focus mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,11 @@ PORT=3001
 # WEBAUTHN_RP_ID=command-central.up.railway.app
 # WEBAUTHN_ORIGIN=https://command-central.up.railway.app
 
-# Legacy integrations (optional, local dev only)
-# JIRA_URL=
+# Jira integration
+# JIRA_URL=https://your-domain.atlassian.net
 # JIRA_EMAIL=
 # JIRA_API_TOKEN=
+# JIRA_WEBHOOK_SECRET=
 # HARVEST_ACCOUNT_ID=
 # HARVEST_ACCESS_TOKEN=
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,17 @@ Database tables are namespaced by module prefix (e.g. `task_items`, `task_lists`
 
 ## Project Tracking
 
-**GitHub Issues are the source of truth** for all tasks, planning, and project details. Not markdown files, not mental notes. Every decision, task, and piece of context gets captured in an issue or issue comment.
+**GitHub Issues are the source of truth** for all tasks, planning, and project details. Not markdown files, not mental notes, not Claude's internal context. Every decision, task, and piece of context gets captured in an issue or issue comment.
+
+### Issue-First Development
+
+**Never start writing code without a GitHub Issue that contains the requirements.** This is a hard rule:
+1. Requirements live in GitHub Issues — not in plans, not in conversation memory
+2. Before starting any implementation, read the issue to get the full requirements
+3. If requirements are unclear or missing from the issue, update the issue first — then implement
+4. Reference the issue number in commits and PRs (`Closes #N`)
+5. Update the issue with progress, decisions, and blockers as work happens
+6. When work is done, the issue should tell the full story of what was built and why
 
 ### Idea Capture
 

--- a/drizzle/0001_lively_greymalkin.sql
+++ b/drizzle/0001_lively_greymalkin.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "task_projects" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"area_id" uuid,
+	"status" text DEFAULT 'active' NOT NULL,
+	"icon" text,
+	"color" text,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "jira_sync_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"webhook_id" text NOT NULL,
+	"issue_key" text NOT NULL,
+	"action" text NOT NULL,
+	"processed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "jira_sync_log_webhook_id_unique" UNIQUE("webhook_id")
+);
+--> statement-breakpoint
+ALTER TABLE "task_items" ADD COLUMN "project_id" uuid;--> statement-breakpoint
+ALTER TABLE "task_items" ADD COLUMN "source" text DEFAULT 'local' NOT NULL;--> statement-breakpoint
+ALTER TABLE "task_items" ADD COLUMN "external_key" text;--> statement-breakpoint
+ALTER TABLE "task_items" ADD COLUMN "external_url" text;--> statement-breakpoint
+ALTER TABLE "task_projects" ADD CONSTRAINT "task_projects_area_id_task_areas_id_fk" FOREIGN KEY ("area_id") REFERENCES "public"."task_areas"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "task_items" ADD CONSTRAINT "task_items_project_id_task_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."task_projects"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "task_items" ADD CONSTRAINT "task_items_external_key_unique" UNIQUE("external_key");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,803 @@
+{
+  "id": "71fe7914-d5a8-410a-bc93-d13191bae0f9",
+  "prevId": "df23b900-c9bf-43ea-80c6-2cee4df32791",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_areas": {
+      "name": "task_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_checklist": {
+      "name": "task_checklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_checklist_task_id_task_items_id_fk": {
+          "name": "task_checklist_task_id_task_items_id_fk",
+          "tableFrom": "task_checklist",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_item_tags": {
+      "name": "task_item_tags",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_item_tags_task_id_task_items_id_fk": {
+          "name": "task_item_tags_task_id_task_items_id_fk",
+          "tableFrom": "task_item_tags",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_item_tags_tag_id_task_tags_id_fk": {
+          "name": "task_item_tags_tag_id_task_tags_id_fk",
+          "tableFrom": "task_item_tags",
+          "tableTo": "task_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_item_tags_task_id_tag_id_pk": {
+          "name": "task_item_tags_task_id_tag_id_pk",
+          "columns": [
+            "task_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_time": {
+          "name": "due_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_parent_id": {
+          "name": "recurrence_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_items_list_id_task_lists_id_fk": {
+          "name": "task_items_list_id_task_lists_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_area_id_task_areas_id_fk": {
+          "name": "task_items_area_id_task_areas_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_project_id_task_projects_id_fk": {
+          "name": "task_items_project_id_task_projects_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_external_key_unique": {
+          "name": "task_items_external_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_lists_area_id_task_areas_id_fk": {
+          "name": "task_lists_area_id_task_areas_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_projects": {
+      "name": "task_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_projects_area_id_task_areas_id_fk": {
+          "name": "task_projects_area_id_task_areas_id_fk",
+          "tableFrom": "task_projects",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_tags": {
+      "name": "task_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_tags_name_unique": {
+          "name": "task_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jira_sync_log": {
+      "name": "jira_sync_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jira_sync_log_webhook_id_unique": {
+          "name": "jira_sync_log_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771097970607,
       "tag": "0000_neat_wither",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771111788478,
+      "tag": "0001_lively_greymalkin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/client/src/components/tasks/QuickAdd.tsx
+++ b/packages/client/src/components/tasks/QuickAdd.tsx
@@ -7,7 +7,11 @@ export interface QuickAddHandle {
   focus: () => void;
 }
 
-const QuickAdd = forwardRef<QuickAddHandle>(function QuickAdd(_props, ref) {
+interface QuickAddProps {
+  focusAreaId?: string | null;
+}
+
+const QuickAdd = forwardRef<QuickAddHandle, QuickAddProps>(function QuickAdd({ focusAreaId }, ref) {
   const [value, setValue] = useState('');
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -27,7 +31,7 @@ const QuickAdd = forwardRef<QuickAddHandle>(function QuickAdd(_props, ref) {
   function handleSubmit() {
     const title = value.trim();
     if (!title) return;
-    create.mutate({ title });
+    create.mutate({ title, ...(focusAreaId ? { areaId: focusAreaId } : {}) });
   }
 
   return (

--- a/packages/client/src/components/tasks/TaskDetail.tsx
+++ b/packages/client/src/components/tasks/TaskDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { X, Trash2, Calendar, Flag, FolderOpen, MapPin, Layers, Repeat } from 'lucide-react';
+import { X, Trash2, Calendar, Flag, FolderOpen, MapPin, Layers, Repeat, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/lib/trpc';
 import TaskCheckbox from './TaskCheckbox';
@@ -80,6 +80,7 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
   }
 
   const isDone = task.status === 'done';
+  const isJira = task.source === 'jira';
 
   return (
     <div className="w-[400px] border-l border-border bg-surface-root flex flex-col flex-shrink-0">
@@ -87,7 +88,20 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
       <div className="flex items-center justify-between px-4 h-14 border-b border-border">
         <div className="flex items-center gap-3">
           <TaskCheckbox checked={isDone} onChange={() => complete.mutate({ id: taskId })} />
-          <span className="text-overline text-muted-foreground uppercase tracking-wider">Task Detail</span>
+          <span className="text-overline text-muted-foreground uppercase tracking-wider">
+            {isJira ? 'Jira Task' : 'Task Detail'}
+          </span>
+          {isJira && task.externalKey && (
+            <a
+              href={task.externalUrl ?? '#'}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-caption text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <span className="font-mono">{task.externalKey}</span>
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
         </div>
         <div className="flex items-center gap-1">
           <button
@@ -111,14 +125,19 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
         {/* Title */}
         <input
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          onBlur={() => title.trim() && title !== task.title && save({ title: title.trim() })}
+          onChange={(e) => !isJira && setTitle(e.target.value)}
+          onBlur={() => !isJira && title.trim() && title !== task.title && save({ title: title.trim() })}
           onKeyDown={(e) => e.key === 'Enter' && (e.target as HTMLInputElement).blur()}
+          readOnly={isJira}
           className={cn(
             'w-full bg-transparent text-heading-3 text-foreground font-semibold focus:outline-none',
             isDone && 'line-through text-muted-foreground',
+            isJira && 'cursor-default',
           )}
         />
+        {isJira && (
+          <p className="text-caption text-muted-foreground/60">Title synced from Jira — edit in Jira to update</p>
+        )}
 
         {/* Notes */}
         <textarea

--- a/packages/client/src/components/tasks/TaskRow.tsx
+++ b/packages/client/src/components/tasks/TaskRow.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 import { cn } from '@/lib/utils';
-import { Star, GripVertical } from 'lucide-react';
+import { Star, GripVertical, ExternalLink } from 'lucide-react';
 import TaskCheckbox from './TaskCheckbox';
 
 export interface TaskRowTask {
@@ -11,6 +11,9 @@ export interface TaskRowTask {
   dueDate?: string | null;
   listId?: string | null;
   areaId?: string | null;
+  source?: string | null;
+  externalKey?: string | null;
+  externalUrl?: string | null;
 }
 
 interface TaskRowProps {
@@ -87,6 +90,22 @@ const TaskRow = forwardRef<HTMLDivElement, TaskRowProps>(function TaskRow(
       </div>
 
       <div className="flex items-center gap-2">
+        {task.source === 'jira' && task.externalKey && (
+          <span className="flex items-center gap-1 text-caption text-muted-foreground/70">
+            <span className="font-mono text-[11px]">{task.externalKey}</span>
+            {task.externalUrl && (
+              <a
+                href={task.externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="hover:text-foreground transition-colors"
+              >
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </span>
+        )}
         {task.priority === 3 && (
           <Star className="h-3.5 w-3.5 text-primary fill-primary" />
         )}

--- a/packages/client/src/components/tasks/TaskSidebar.tsx
+++ b/packages/client/src/components/tasks/TaskSidebar.tsx
@@ -4,6 +4,7 @@ import { trpc } from '@/lib/trpc';
 import {
   Inbox, CalendarDays, CalendarClock, ListChecks,
   ChevronRight, Plus, FolderOpen, MapPin, Layers,
+  Crosshair, RefreshCw,
 } from 'lucide-react';
 
 type ViewKey = 'inbox' | 'today' | 'upcoming' | 'all';
@@ -13,10 +14,12 @@ interface TaskSidebarProps {
   activeListId: string | null;
   activeAreaId: string | null;
   activeProjectId: string | null;
+  focusAreaId: string | null;
   onViewChange: (view: ViewKey) => void;
   onListSelect: (listId: string) => void;
   onAreaSelect: (areaId: string) => void;
   onProjectSelect: (projectId: string) => void;
+  onFocusArea: (areaId: string | null) => void;
 }
 
 const smartViews = [
@@ -27,8 +30,8 @@ const smartViews = [
 ];
 
 export default function TaskSidebar({
-  activeView, activeListId, activeAreaId, activeProjectId,
-  onViewChange, onListSelect, onAreaSelect, onProjectSelect,
+  activeView, activeListId, activeAreaId, activeProjectId, focusAreaId,
+  onViewChange, onListSelect, onAreaSelect, onProjectSelect, onFocusArea,
 }: TaskSidebarProps) {
   const { data: areas = [] } = trpc.tasks.areas.list.useQuery();
   const { data: lists = [] } = trpc.tasks.lists.list.useQuery();
@@ -52,6 +55,18 @@ export default function TaskSidebar({
   const [newProjectAreaId, setNewProjectAreaId] = useState<string | null>(null);
   const [newProjectName, setNewProjectName] = useState('');
   const [expandedAreas, setExpandedAreas] = useState<Set<string>>(new Set());
+
+  const { data: jiraStatus } = trpc.jira.status.useQuery(undefined, {
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const jiraSync = trpc.jira.sync.useMutation({
+    onSuccess: () => {
+      utils.tasks.list.invalidate();
+      utils.tasks.areas.list.invalidate();
+      utils.tasks.projects.list.invalidate();
+    },
+  });
 
   function toggleArea(areaId: string) {
     setExpandedAreas((prev) => {
@@ -109,7 +124,38 @@ export default function TaskSidebar({
         ))}
       </div>
 
+      {/* Jira sync */}
+      {jiraStatus?.configured && (
+        <div className="px-2 pb-1">
+          <button
+            onClick={() => jiraSync.mutate()}
+            disabled={jiraSync.isPending}
+            className={cn(
+              'flex items-center gap-2 w-full px-2.5 py-1.5 rounded-md text-body transition-colors duration-150',
+              'text-muted-foreground hover:text-foreground hover:bg-surface-overlay',
+              jiraSync.isPending && 'opacity-50 cursor-wait',
+            )}
+          >
+            <RefreshCw className={cn('h-4 w-4 flex-shrink-0', jiraSync.isPending && 'animate-spin')} />
+            <span>{jiraSync.isPending ? 'Syncing...' : 'Sync Jira'}</span>
+          </button>
+        </div>
+      )}
+
       <div className="mx-2 my-2 border-t border-border" />
+
+      {/* Focus mode indicator */}
+      {focusAreaId && (
+        <div className="px-2 pb-1">
+          <button
+            onClick={() => onFocusArea(null)}
+            className="flex items-center gap-2 w-full px-2.5 py-1.5 rounded-md text-body text-primary bg-primary/10 hover:bg-primary/15 transition-colors"
+          >
+            <Crosshair className="h-4 w-4" />
+            <span>All Areas</span>
+          </button>
+        </div>
+      )}
 
       {/* Areas with nested lists */}
       <div className="p-2 space-y-1">
@@ -140,7 +186,7 @@ export default function TaskSidebar({
           </div>
         )}
 
-        {areas.map((area: any) => {
+        {areas.filter((a: any) => !focusAreaId || a.id === focusAreaId).map((area: any) => {
           const areaLists = lists.filter((l: any) => l.areaId === area.id);
           const areaProjects = projects.filter((p: any) => p.areaId === area.id);
           const expanded = expandedAreas.has(area.id);
@@ -165,6 +211,18 @@ export default function TaskSidebar({
                 >
                   <MapPin className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{area.name}</span>
+                </button>
+                <button
+                  onClick={() => onFocusArea(focusAreaId === area.id ? null : area.id)}
+                  className={cn(
+                    'p-1 rounded transition-colors',
+                    focusAreaId === area.id
+                      ? 'text-primary'
+                      : 'text-muted-foreground/0 hover:text-muted-foreground',
+                  )}
+                  title={focusAreaId === area.id ? 'Clear focus' : 'Focus on this area'}
+                >
+                  <Crosshair className="h-3 w-3" />
                 </button>
                 <button
                   onClick={() => { setNewListAreaId(area.id); setExpandedAreas((p) => new Set(p).add(area.id)); }}

--- a/packages/client/src/pages/TasksPage.tsx
+++ b/packages/client/src/pages/TasksPage.tsx
@@ -17,7 +17,19 @@ export default function TasksPage() {
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [showCompleted, setShowCompleted] = useState(false);
+  const [focusAreaId, setFocusAreaId] = useState<string | null>(
+    () => localStorage.getItem('cc-focus-area-id') || null,
+  );
   const quickAddRef = useRef<QuickAddHandle>(null);
+
+  function handleFocusArea(areaId: string | null) {
+    setFocusAreaId(areaId);
+    if (areaId) {
+      localStorage.setItem('cc-focus-area-id', areaId);
+    } else {
+      localStorage.removeItem('cc-focus-area-id');
+    }
+  }
 
   useKeyboardShortcuts(useMemo(() => ({
     'n': () => quickAddRef.current?.focus(),
@@ -34,6 +46,9 @@ export default function TasksPage() {
     filter.areaId = activeAreaId;
   } else {
     filter.view = activeView;
+  }
+  if (focusAreaId) {
+    filter.focusAreaId = focusAreaId;
   }
 
   const { data: tasks = [], isLoading } = trpc.tasks.list.useQuery(filter);
@@ -88,17 +103,19 @@ export default function TasksPage() {
         activeListId={activeListId}
         activeAreaId={activeAreaId}
         activeProjectId={activeProjectId}
+        focusAreaId={focusAreaId}
         onViewChange={handleViewChange}
         onListSelect={handleListSelect}
         onAreaSelect={handleAreaSelect}
         onProjectSelect={handleProjectSelect}
+        onFocusArea={handleFocusArea}
       />
 
       <div className="flex flex-col flex-1 min-w-0">
         {/* Task list */}
         <div className="flex-1 overflow-y-auto p-6">
           <div className="max-w-2xl mx-auto space-y-3">
-            <QuickAdd ref={quickAddRef} />
+            <QuickAdd ref={quickAddRef} focusAreaId={focusAreaId} />
 
             {isLoading ? (
               <div className="space-y-3 mt-4">

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './tasks';
+export * from './jira';

--- a/packages/server/src/db/schema/jira.ts
+++ b/packages/server/src/db/schema/jira.ts
@@ -1,0 +1,9 @@
+import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+export const jiraSyncLog = pgTable('jira_sync_log', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  webhookId: text('webhook_id').unique().notNull(),
+  issueKey: text('issue_key').notNull(),
+  action: text('action', { enum: ['created', 'updated', 'deleted'] }).notNull(),
+  processedAt: timestamp('processed_at', { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/db/schema/tasks.ts
+++ b/packages/server/src/db/schema/tasks.ts
@@ -55,6 +55,9 @@ export const taskItems = pgTable('task_items', {
   sortOrder: integer('sort_order').notNull().default(0),
   recurrenceRule: text('recurrence_rule'),
   recurrenceParentId: uuid('recurrence_parent_id'),
+  source: text('source', { enum: ['local', 'jira'] }).notNull().default('local'),
+  externalKey: text('external_key').unique(),
+  externalUrl: text('external_url'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });

--- a/packages/server/src/di/container.ts
+++ b/packages/server/src/di/container.ts
@@ -10,6 +10,7 @@ import { TagRepository } from '../services/tag-repository.js';
 import { ChecklistRepository } from '../services/checklist-repository.js';
 import { ProjectRepository } from '../services/project-repository.js';
 import { TaskService } from '../services/task-service.js';
+import { JiraService } from '../services/jira-service.js';
 
 export function createContainer(): Container {
   const container = new Container();
@@ -30,6 +31,7 @@ export function createContainer(): Container {
 
   // Services — singleton
   container.bind(SYMBOLS.TaskService).to(TaskService).inSingletonScope();
+  container.bind(SYMBOLS.JiraService).to(JiraService).inSingletonScope();
 
   return container;
 }

--- a/packages/server/src/di/symbols.ts
+++ b/packages/server/src/di/symbols.ts
@@ -8,4 +8,5 @@ export const SYMBOLS = {
   ChecklistRepository: Symbol.for('ChecklistRepository'),
   ProjectRepository: Symbol.for('ProjectRepository'),
   TaskService: Symbol.for('TaskService'),
+  JiraService: Symbol.for('JiraService'),
 } as const;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ import { setupTerminalWebSocket } from './services/terminal-ws.js';
 import { createContainer } from './di/container.js';
 import { appRouter } from './trpc/router.js';
 import { createContextFactory } from './trpc/context.js';
+import { createWebhookRouter } from './routes/webhooks.js';
 
 // Legacy imports
 import db from './db.js';
@@ -50,6 +51,9 @@ app.use(
     createContext: createContextFactory(container),
   }),
 );
+
+// Webhook routes (no auth cookie — secret-based)
+app.use('/api/webhooks', createWebhookRouter(container));
 
 // Legacy Express routes
 app.use('/api/projects', projectsRouter);

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import type { Container } from 'inversify';
+import { SYMBOLS } from '../di/symbols.js';
+import { JiraService } from '../services/jira-service.js';
+
+export function createWebhookRouter(container: Container): Router {
+  const router = Router();
+
+  router.post('/jira', async (req, res) => {
+    const secret = req.query.secret as string | undefined;
+    const expectedSecret = process.env.JIRA_WEBHOOK_SECRET;
+
+    if (!expectedSecret || secret !== expectedSecret) {
+      res.status(401).json({ error: 'Invalid webhook secret' });
+      return;
+    }
+
+    try {
+      const jira = container.get<JiraService>(SYMBOLS.JiraService);
+      await jira.processWebhook(req.body);
+      res.json({ ok: true });
+    } catch (err) {
+      console.error('Jira webhook error:', err);
+      res.status(500).json({ error: 'Webhook processing failed' });
+    }
+  });
+
+  return router;
+}

--- a/packages/server/src/services/jira-service.ts
+++ b/packages/server/src/services/jira-service.ts
@@ -1,0 +1,229 @@
+import { injectable, inject } from 'inversify';
+import { eq } from 'drizzle-orm';
+import { SYMBOLS } from '../di/symbols.js';
+import { taskItems, taskAreas, taskProjects } from '../db/schema/tasks.js';
+import { jiraSyncLog } from '../db/schema/jira.js';
+import type { Database } from '../db/drizzle.js';
+
+export interface JiraIssue {
+  key: string;
+  summary: string;
+  status: string;
+  statusCategory: string;
+  priority: string;
+  projectKey: string;
+  projectName: string;
+  url: string;
+}
+
+function mapStatusCategory(category: string): 'todo' | 'done' {
+  return category === 'done' ? 'done' : 'todo';
+}
+
+function mapPriority(jiraPriority: string): number {
+  const name = jiraPriority.toLowerCase();
+  if (name === 'highest' || name === 'high') return 3;
+  if (name === 'medium') return 2;
+  if (name === 'low' || name === 'lowest') return 1;
+  return 0;
+}
+
+@injectable()
+export class JiraService {
+  constructor(@inject(SYMBOLS.Database) private db: Database) {}
+
+  isConfigured(): boolean {
+    const { JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN } = process.env;
+    return !!(JIRA_URL && JIRA_EMAIL && JIRA_API_TOKEN);
+  }
+
+  private async jiraFetch(path: string, init?: RequestInit) {
+    const { JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN } = process.env;
+    const auth = Buffer.from(`${JIRA_EMAIL}:${JIRA_API_TOKEN}`).toString('base64');
+    const res = await fetch(`${JIRA_URL}${path}`, {
+      ...init,
+      headers: {
+        'Authorization': `Basic ${auth}`,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        ...init?.headers,
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw new Error(`Jira API ${res.status}: ${text}`);
+    }
+    return res.json();
+  }
+
+  async getMyIssues(): Promise<JiraIssue[]> {
+    const jql = 'assignee = currentUser() AND status != Done ORDER BY updated DESC';
+    const data = await this.jiraFetch('/rest/api/3/search/jql', {
+      method: 'POST',
+      body: JSON.stringify({
+        jql,
+        maxResults: 50,
+        fields: ['summary', 'status', 'priority', 'project', 'updated', 'assignee'],
+      }),
+    });
+
+    const baseUrl = process.env.JIRA_URL!;
+    return (data.issues ?? []).map((issue: any) => ({
+      key: issue.key,
+      summary: issue.fields.summary,
+      status: issue.fields.status?.name ?? 'Unknown',
+      statusCategory: issue.fields.status?.statusCategory?.key ?? 'undefined',
+      priority: issue.fields.priority?.name ?? 'None',
+      projectKey: issue.fields.project?.key ?? '',
+      projectName: issue.fields.project?.name ?? '',
+      url: `${baseUrl}/browse/${issue.key}`,
+    }));
+  }
+
+  async syncAllIssues(): Promise<{ created: number; updated: number }> {
+    const issues = await this.getMyIssues();
+    const workArea = await this.ensureWorkArea();
+    let created = 0;
+    let updated = 0;
+
+    for (const issue of issues) {
+      const project = await this.ensureProject(issue.projectKey, issue.projectName, workArea.id);
+      const result = await this.upsertTask(issue, workArea.id, project.id);
+      if (result === 'created') created++;
+      else updated++;
+    }
+
+    return { created, updated };
+  }
+
+  async syncSingleIssue(issueKey: string): Promise<void> {
+    const data: any = await this.jiraFetch(
+      `/rest/api/3/issue/${issueKey}?fields=summary,status,priority,project`
+    );
+    const baseUrl = process.env.JIRA_URL!;
+    const issue: JiraIssue = {
+      key: data.key,
+      summary: data.fields.summary,
+      status: data.fields.status?.name ?? 'Unknown',
+      statusCategory: data.fields.status?.statusCategory?.key ?? 'undefined',
+      priority: data.fields.priority?.name ?? 'None',
+      projectKey: data.fields.project?.key ?? '',
+      projectName: data.fields.project?.name ?? '',
+      url: `${baseUrl}/browse/${data.key}`,
+    };
+
+    const workArea = await this.ensureWorkArea();
+    const project = await this.ensureProject(issue.projectKey, issue.projectName, workArea.id);
+    await this.upsertTask(issue, workArea.id, project.id);
+  }
+
+  async processWebhook(payload: any): Promise<void> {
+    const webhookEvent = payload.webhookEvent as string | undefined;
+    const issueKey = payload.issue?.key as string | undefined;
+    const webhookId = payload.matchedWebhookIds?.[0]?.toString()
+      ?? `${issueKey}-${Date.now()}`;
+
+    if (!issueKey) return;
+
+    // Dedup check
+    const [existing] = await this.db
+      .select()
+      .from(jiraSyncLog)
+      .where(eq(jiraSyncLog.webhookId, webhookId));
+    if (existing) return;
+
+    let action: 'created' | 'updated' | 'deleted' = 'updated';
+
+    if (webhookEvent === 'jira:issue_deleted') {
+      action = 'deleted';
+      // Mark CC task as cancelled
+      const [task] = await this.db
+        .select()
+        .from(taskItems)
+        .where(eq(taskItems.externalKey, issueKey));
+      if (task) {
+        await this.db
+          .update(taskItems)
+          .set({ status: 'cancelled', updatedAt: new Date() })
+          .where(eq(taskItems.id, task.id));
+      }
+    } else if (webhookEvent === 'jira:issue_created') {
+      action = 'created';
+      await this.syncSingleIssue(issueKey);
+    } else {
+      await this.syncSingleIssue(issueKey);
+    }
+
+    // Log for dedup
+    await this.db.insert(jiraSyncLog).values({
+      webhookId,
+      issueKey,
+      action,
+    });
+  }
+
+  private async ensureWorkArea() {
+    const [existing] = await this.db
+      .select()
+      .from(taskAreas)
+      .where(eq(taskAreas.name, 'Work'));
+    if (existing) return existing;
+
+    const [area] = await this.db
+      .insert(taskAreas)
+      .values({ name: 'Work', icon: '💼', color: 'blue' })
+      .returning();
+    return area;
+  }
+
+  private async ensureProject(projectKey: string, projectName: string, areaId: string) {
+    // Match by name prefixed with project key
+    const name = `${projectKey}: ${projectName}`;
+    const allProjects = await this.db.select().from(taskProjects);
+    const existing = allProjects.find(p => p.name === name);
+    if (existing) return existing;
+
+    const [project] = await this.db
+      .insert(taskProjects)
+      .values({ name, areaId, icon: '🔧' })
+      .returning();
+    return project;
+  }
+
+  private async upsertTask(
+    issue: JiraIssue,
+    areaId: string,
+    projectId: string
+  ): Promise<'created' | 'updated'> {
+    const [existing] = await this.db
+      .select()
+      .from(taskItems)
+      .where(eq(taskItems.externalKey, issue.key));
+
+    const taskData = {
+      title: issue.summary,
+      status: mapStatusCategory(issue.statusCategory),
+      priority: mapPriority(issue.priority),
+      source: 'jira' as const,
+      externalKey: issue.key,
+      externalUrl: issue.url,
+      areaId,
+      projectId,
+      updatedAt: new Date(),
+    };
+
+    if (existing) {
+      await this.db
+        .update(taskItems)
+        .set(taskData)
+        .where(eq(taskItems.id, existing.id));
+      return 'updated';
+    }
+
+    await this.db
+      .insert(taskItems)
+      .values(taskData)
+      .returning();
+    return 'created';
+  }
+}

--- a/packages/server/src/services/task-repository.ts
+++ b/packages/server/src/services/task-repository.ts
@@ -1,7 +1,7 @@
 import { injectable, inject } from 'inversify';
-import { eq, and, isNull, lte, gte, sql, asc, ne } from 'drizzle-orm';
+import { eq, and, or, isNull, lte, gte, sql, asc, ne, inArray } from 'drizzle-orm';
 import { SYMBOLS } from '../di/symbols.js';
-import { taskItems, taskItemTags } from '../db/schema/tasks.js';
+import { taskItems, taskItemTags, taskLists, taskProjects } from '../db/schema/tasks.js';
 import type { Database } from '../db/drizzle.js';
 import type { TaskFilter } from '@cc/shared';
 
@@ -43,6 +43,25 @@ export class TaskRepository {
       const weekFromNow = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
       conditions.push(gte(taskItems.dueDate, today));
       conditions.push(lte(taskItems.dueDate, weekFromNow));
+    }
+
+    if (filter.focusAreaId) {
+      const listIdsInArea = this.db
+        .select({ id: taskLists.id })
+        .from(taskLists)
+        .where(eq(taskLists.areaId, filter.focusAreaId));
+      const projectIdsInArea = this.db
+        .select({ id: taskProjects.id })
+        .from(taskProjects)
+        .where(eq(taskProjects.areaId, filter.focusAreaId));
+
+      conditions.push(
+        or(
+          eq(taskItems.areaId, filter.focusAreaId),
+          inArray(taskItems.listId, listIdsInArea),
+          inArray(taskItems.projectId, projectIdsInArea),
+        )!,
+      );
     }
 
     const where = conditions.length > 0 ? and(...conditions) : undefined;

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -1,10 +1,12 @@
 import { router } from './trpc.js';
 import { authRouter } from './routers/auth.js';
 import { tasksRouter } from './routers/tasks.js';
+import { jiraRouter } from './routers/jira.js';
 
 export const appRouter = router({
   auth: authRouter,
   tasks: tasksRouter,
+  jira: jiraRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/server/src/trpc/routers/jira.ts
+++ b/packages/server/src/trpc/routers/jira.ts
@@ -1,0 +1,28 @@
+import { router, protectedProcedure } from '../trpc.js';
+import { SYMBOLS } from '../../di/symbols.js';
+import { JiraService } from '../../services/jira-service.js';
+
+export const jiraRouter = router({
+  status: protectedProcedure.query(async ({ ctx }) => {
+    const jira = ctx.container.get<JiraService>(SYMBOLS.JiraService);
+    const configured = jira.isConfigured();
+    let issueCount = 0;
+    if (configured) {
+      try {
+        const issues = await jira.getMyIssues();
+        issueCount = issues.length;
+      } catch {
+        // Jira may be unreachable — still report configured
+      }
+    }
+    return { configured, issueCount };
+  }),
+
+  sync: protectedProcedure.mutation(async ({ ctx }) => {
+    const jira = ctx.container.get<JiraService>(SYMBOLS.JiraService);
+    if (!jira.isConfigured()) {
+      throw new Error('Jira is not configured. Set JIRA_URL, JIRA_EMAIL, and JIRA_API_TOKEN.');
+    }
+    return jira.syncAllIssues();
+  }),
+});

--- a/packages/shared/src/schemas/tasks.ts
+++ b/packages/shared/src/schemas/tasks.ts
@@ -64,6 +64,9 @@ export const TaskChecklist = z.object({
 });
 export type TaskChecklist = z.infer<typeof TaskChecklist>;
 
+export const TaskSource = z.enum(['local', 'jira']);
+export type TaskSource = z.infer<typeof TaskSource>;
+
 export const TaskItem = z.object({
   id: z.string().uuid(),
   title: z.string().min(1),
@@ -79,6 +82,9 @@ export const TaskItem = z.object({
   sortOrder: z.number().int().default(0),
   recurrenceRule: z.string().nullish(), // iCal RRULE
   recurrenceParentId: z.string().uuid().nullish(),
+  source: TaskSource.default('local'),
+  externalKey: z.string().nullish(),
+  externalUrl: z.string().nullish(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
 });
@@ -125,6 +131,7 @@ export const TaskFilter = z.object({
   areaId: z.string().uuid().optional(),
   projectId: z.string().uuid().optional(),
   status: TaskStatus.optional(),
+  focusAreaId: z.string().uuid().optional(),
 });
 export type TaskFilter = z.infer<typeof TaskFilter>;
 


### PR DESCRIPTION
## Summary
- Adds `source`, `externalKey`, `externalUrl` columns to `taskItems` table for tracking externally-sourced tasks
- Creates `jira_sync_log` table for webhook deduplication
- Implements `JiraService` (Inversify singleton) with full sync logic — fetches assigned Jira issues, auto-creates "Work" area and per-project grouping, upserts tasks by external key
- Adds tRPC `jira.status` and `jira.sync` endpoints
- Adds Express webhook route at `POST /api/webhooks/jira` with secret-based auth
- Client: Jira badge + external link on task rows, read-only title for Jira tasks in detail panel, "Sync Jira" button in sidebar
- Client: Area-based focus mode — crosshair toggle per area, filters all smart views to focused area, persists to localStorage
- QuickAdd defaults to focused area when focus mode is active

## Closes
- Closes #37 — DB schema changes
- Closes #38 — JiraService with DI
- Closes #39 — tRPC jira router
- Closes #40 — Client UI for Jira
- Closes #41 — Area-based focus mode
- Closes #42 — Webhook endpoint

## Test plan
- [ ] Set `JIRA_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` in `.env`
- [ ] Click "Sync Jira" in sidebar → issues appear as tasks under auto-created "Work" area
- [ ] Jira tasks show issue key badge and external link in task row
- [ ] Jira task detail shows read-only title with "synced from Jira" note
- [ ] Focus on "Work" area → only work tasks visible in smart views
- [ ] Clear focus → all tasks visible again
- [ ] QuickAdd creates tasks in focused area when focus is active
- [ ] Webhook: `curl -X POST localhost:3001/api/webhooks/jira?secret=<secret>` with Jira payload
- [ ] `pnpm typecheck` passes for both server and client
- [ ] Existing e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)