### PR TITLE
Add project dates and detail header

### DIFF
--- a/drizzle/0003_overconfident_sunspot.sql
+++ b/drizzle/0003_overconfident_sunspot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "task_projects" ADD COLUMN "start_date" date;--> statement-breakpoint
+ALTER TABLE "task_projects" ADD COLUMN "due_date" date;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,833 @@
+{
+  "id": "782c903b-e8b5-4bfe-8095-cb56d2eb16df",
+  "prevId": "def65899-1750-4a13-8017-ab6b180d38be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_areas": {
+      "name": "task_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_checklist": {
+      "name": "task_checklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_checklist_task_id_task_items_id_fk": {
+          "name": "task_checklist_task_id_task_items_id_fk",
+          "tableFrom": "task_checklist",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_item_tags": {
+      "name": "task_item_tags",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_item_tags_task_id_task_items_id_fk": {
+          "name": "task_item_tags_task_id_task_items_id_fk",
+          "tableFrom": "task_item_tags",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_item_tags_tag_id_task_tags_id_fk": {
+          "name": "task_item_tags_tag_id_task_tags_id_fk",
+          "tableFrom": "task_item_tags",
+          "tableTo": "task_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_item_tags_task_id_tag_id_pk": {
+          "name": "task_item_tags_task_id_tag_id_pk",
+          "columns": [
+            "task_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_time": {
+          "name": "due_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_minutes": {
+          "name": "estimate_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_spent_minutes": {
+          "name": "time_spent_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_parent_id": {
+          "name": "recurrence_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_items_list_id_task_lists_id_fk": {
+          "name": "task_items_list_id_task_lists_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_area_id_task_areas_id_fk": {
+          "name": "task_items_area_id_task_areas_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_project_id_task_projects_id_fk": {
+          "name": "task_items_project_id_task_projects_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_external_key_unique": {
+          "name": "task_items_external_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_lists_area_id_task_areas_id_fk": {
+          "name": "task_lists_area_id_task_areas_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_projects": {
+      "name": "task_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_projects_area_id_task_areas_id_fk": {
+          "name": "task_projects_area_id_task_areas_id_fk",
+          "tableFrom": "task_projects",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_tags": {
+      "name": "task_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_tags_name_unique": {
+          "name": "task_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jira_sync_log": {
+      "name": "jira_sync_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jira_sync_log_webhook_id_unique": {
+          "name": "jira_sync_log_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1771112668159,
       "tag": "0002_organic_typhoid_mary",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1771114735989,
+      "tag": "0003_overconfident_sunspot",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/client/src/components/tasks/ProjectHeader.tsx
+++ b/packages/client/src/components/tasks/ProjectHeader.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from 'react';
+import { Layers, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { trpc } from '@/lib/trpc';
+import { DatePicker } from '@/components/ui/date-picker';
+
+const statusOptions = [
+  { value: 'active', label: 'Active', color: 'text-status-info' },
+  { value: 'on_hold', label: 'On Hold', color: 'text-status-urgency-low' },
+  { value: 'completed', label: 'Completed', color: 'text-green-500' },
+  { value: 'archived', label: 'Archived', color: 'text-muted-foreground/50' },
+];
+
+interface ProjectHeaderProps {
+  projectId: string;
+  onDeleted: () => void;
+}
+
+export default function ProjectHeader({ projectId, onDeleted }: ProjectHeaderProps) {
+  const utils = trpc.useUtils();
+  const { data: project } = trpc.tasks.projects.get.useQuery({ id: projectId });
+  const { data: tasks = [] } = trpc.tasks.list.useQuery({ projectId });
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState('active');
+  const [startDate, setStartDate] = useState('');
+  const [dueDate, setDueDate] = useState('');
+
+  useEffect(() => {
+    if (project) {
+      setName(project.name);
+      setDescription(project.description ?? '');
+      setStatus(project.status);
+      setStartDate(project.startDate ? new Date(project.startDate).toISOString().split('T')[0] : '');
+      setDueDate(project.dueDate ? new Date(project.dueDate).toISOString().split('T')[0] : '');
+    }
+  }, [project]);
+
+  const update = trpc.tasks.projects.update.useMutation({
+    onSuccess: () => {
+      utils.tasks.projects.list.invalidate();
+      utils.tasks.projects.get.invalidate({ id: projectId });
+    },
+  });
+
+  const deleteMutation = trpc.tasks.projects.delete.useMutation({
+    onSuccess: () => {
+      utils.tasks.projects.list.invalidate();
+      utils.tasks.list.invalidate();
+      onDeleted();
+    },
+  });
+
+  function save(fields: Record<string, any>) {
+    update.mutate({ id: projectId, ...fields });
+  }
+
+  if (!project) return null;
+
+  const doneTasks = tasks.filter((t: any) => t.status === 'done').length;
+  const totalTasks = tasks.length;
+  const progress = totalTasks > 0 ? Math.round((doneTasks / totalTasks) * 100) : 0;
+
+  return (
+    <div className="mb-6 space-y-3">
+      {/* Title row */}
+      <div className="flex items-start gap-3">
+        <Layers className="h-5 w-5 text-muted-foreground mt-1 flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={() => name.trim() && name !== project.name && save({ name: name.trim() })}
+            onKeyDown={(e) => e.key === 'Enter' && (e.target as HTMLInputElement).blur()}
+            className="w-full bg-transparent text-heading-3 text-foreground font-semibold focus:outline-none"
+          />
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            onBlur={() => description !== (project.description ?? '') && save({ description: description || null })}
+            placeholder="Add project description..."
+            rows={1}
+            className="w-full bg-transparent text-body text-muted-foreground placeholder:text-muted-foreground/50 focus:outline-none resize-none mt-1"
+          />
+        </div>
+        <button
+          onClick={() => deleteMutation.mutate({ id: projectId })}
+          className="p-1.5 rounded-md text-muted-foreground hover:text-status-error hover:bg-status-error/10 transition-colors"
+          title="Delete project"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Status pills */}
+      <div className="flex items-center gap-1 ml-8">
+        {statusOptions.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => {
+              setStatus(opt.value);
+              save({ status: opt.value });
+            }}
+            className={cn(
+              'px-2 py-1 rounded text-caption transition-colors',
+              status === opt.value
+                ? `bg-primary/15 ${opt.color}`
+                : 'text-muted-foreground hover:text-foreground hover:bg-surface-overlay',
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Dates + progress row */}
+      <div className="flex items-center gap-4 ml-8 flex-wrap">
+        <DatePicker
+          value={startDate}
+          onChange={(val) => { setStartDate(val); save({ startDate: val || null }); }}
+          placeholder="Start date"
+        />
+        <DatePicker
+          value={dueDate}
+          onChange={(val) => { setDueDate(val); save({ dueDate: val || null }); }}
+          placeholder="Due date"
+        />
+        {totalTasks > 0 && (
+          <span className="text-caption text-muted-foreground">
+            {doneTasks}/{totalTasks} tasks ({progress}%)
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      {totalTasks > 0 && (
+        <div className="ml-8 h-1.5 rounded-full bg-surface-overlay overflow-hidden">
+          <div
+            className="h-full bg-primary transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      )}
+
+      <div className="border-b border-border" />
+    </div>
+  );
+}

--- a/packages/client/src/components/tasks/TaskSidebar.tsx
+++ b/packages/client/src/components/tasks/TaskSidebar.tsx
@@ -102,6 +102,7 @@ export default function TaskSidebar({
   }
 
   const unassignedLists = lists.filter((l: any) => !l.areaId);
+  const unassignedProjects = projects.filter((p: any) => !p.areaId);
 
   return (
     <div className="w-52 flex-shrink-0 border-r border-border bg-surface-root overflow-y-auto">
@@ -192,7 +193,7 @@ export default function TaskSidebar({
           const expanded = expandedAreas.has(area.id);
 
           return (
-            <div key={area.id}>
+            <div key={area.id} className="group/area">
               <div className="flex items-center">
                 <button
                   onClick={() => toggleArea(area.id)}
@@ -226,10 +227,17 @@ export default function TaskSidebar({
                 </button>
                 <button
                   onClick={() => { setNewListAreaId(area.id); setExpandedAreas((p) => new Set(p).add(area.id)); }}
-                  className="p-1 text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-1 text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/area:opacity-100"
                   title="Add list"
                 >
-                  <Plus className="h-3 w-3" />
+                  <FolderOpen className="h-3 w-3" />
+                </button>
+                <button
+                  onClick={() => { setNewProjectAreaId(area.id); setExpandedAreas((p) => new Set(p).add(area.id)); }}
+                  className="p-1 text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/area:opacity-100"
+                  title="Add project"
+                >
+                  <Layers className="h-3 w-3" />
                 </button>
               </div>
 
@@ -302,8 +310,8 @@ export default function TaskSidebar({
           );
         })}
 
-        {/* Unassigned lists */}
-        {unassignedLists.length > 0 && (
+        {/* Unassigned lists and projects */}
+        {(unassignedLists.length > 0 || unassignedProjects.length > 0) && (
           <>
             <div className="mx-2.5 my-1 border-t border-border" />
             {unassignedLists.map((list: any) => (
@@ -319,6 +327,21 @@ export default function TaskSidebar({
               >
                 <FolderOpen className="h-3.5 w-3.5 flex-shrink-0" />
                 <span className="truncate">{list.name}</span>
+              </button>
+            ))}
+            {unassignedProjects.map((project: any) => (
+              <button
+                key={project.id}
+                onClick={() => onProjectSelect(project.id)}
+                className={cn(
+                  'flex items-center gap-2 w-full px-2.5 py-1.5 rounded-md text-body transition-colors duration-150',
+                  activeProjectId === project.id
+                    ? 'bg-primary/15 text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-surface-overlay',
+                )}
+              >
+                <Layers className="h-3.5 w-3.5 flex-shrink-0" />
+                <span className="truncate">{project.name}</span>
               </button>
             ))}
           </>

--- a/packages/client/src/pages/TasksPage.tsx
+++ b/packages/client/src/pages/TasksPage.tsx
@@ -3,6 +3,7 @@ import { trpc } from '@/lib/trpc';
 import { Inbox } from 'lucide-react';
 import TaskRow from '@/components/tasks/TaskRow';
 import TaskDetail from '@/components/tasks/TaskDetail';
+import ProjectHeader from '@/components/tasks/ProjectHeader';
 import TaskSidebar from '@/components/tasks/TaskSidebar';
 import SortableTaskList from '@/components/tasks/SortableTaskList';
 import QuickAdd, { type QuickAddHandle } from '@/components/tasks/QuickAdd';
@@ -115,6 +116,12 @@ export default function TasksPage() {
         {/* Task list */}
         <div className="flex-1 overflow-y-auto p-6">
           <div className="max-w-2xl mx-auto space-y-3">
+            {activeProjectId && (
+              <ProjectHeader
+                projectId={activeProjectId}
+                onDeleted={() => { setActiveProjectId(null); setActiveView('inbox'); }}
+              />
+            )}
             <QuickAdd ref={quickAddRef} focusAreaId={focusAreaId} />
 
             {isLoading ? (

--- a/packages/server/src/db/schema/tasks.ts
+++ b/packages/server/src/db/schema/tasks.ts
@@ -29,6 +29,8 @@ export const taskProjects = pgTable('task_projects', {
   status: text('status', { enum: ['active', 'completed', 'on_hold', 'archived'] }).notNull().default('active'),
   icon: text('icon'),
   color: text('color'),
+  startDate: date('start_date'),
+  dueDate: date('due_date'),
   sortOrder: integer('sort_order').notNull().default(0),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/schemas/tasks.ts
+++ b/packages/shared/src/schemas/tasks.ts
@@ -49,6 +49,8 @@ export const TaskProject = z.object({
   status: ProjectStatus.default('active'),
   icon: z.string().nullish(),
   color: z.string().nullish(),
+  startDate: z.string().nullish(),
+  dueDate: z.string().nullish(),
   sortOrder: z.number().int().default(0),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
@@ -189,6 +191,8 @@ export const CreateProjectInput = z.object({
   areaId: z.string().uuid().nullish(),
   icon: z.string().nullish(),
   color: z.string().nullish(),
+  startDate: z.string().nullish(),
+  dueDate: z.string().nullish(),
 });
 export type CreateProjectInput = z.infer<typeof CreateProjectInput>;
 


### PR DESCRIPTION
## Summary
- Adds `startDate` and `dueDate` columns to `taskProjects` table (Closes #45)
- New `ProjectHeader` component shown when a project is selected — editable name, description, status pills, date pickers, task progress bar, delete button (Closes #33)
- Drizzle migration `0003_overconfident_sunspot.sql`
- Updated shared Zod schemas (`TaskProject`, `CreateProjectInput`, `UpdateProjectInput`)

## Test plan
- [ ] Select a project in sidebar — header appears with name, description, status, dates, progress
- [ ] Edit project name and description inline
- [ ] Toggle project status via pills
- [ ] Set start and due dates via calendar pickers
- [ ] Progress bar reflects completed vs total tasks
- [ ] Delete project from header
- [ ] Existing task detail and checklist functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)