### PR TITLE
Add unassigned task visibility and triage flow

### DIFF
--- a/packages/client/src/components/tasks/QuickAdd.tsx
+++ b/packages/client/src/components/tasks/QuickAdd.tsx
@@ -9,9 +9,11 @@ export interface QuickAddHandle {
 
 interface QuickAddProps {
   focusAreaId?: string | null;
+  projectId?: string | null;
+  areaId?: string | null;
 }
 
-const QuickAdd = forwardRef<QuickAddHandle, QuickAddProps>(function QuickAdd({ focusAreaId }, ref) {
+const QuickAdd = forwardRef<QuickAddHandle, QuickAddProps>(function QuickAdd({ focusAreaId, projectId, areaId }, ref) {
   const [value, setValue] = useState('');
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -31,7 +33,11 @@ const QuickAdd = forwardRef<QuickAddHandle, QuickAddProps>(function QuickAdd({ f
   function handleSubmit() {
     const title = value.trim();
     if (!title) return;
-    create.mutate({ title, ...(focusAreaId ? { areaId: focusAreaId } : {}) });
+    create.mutate({
+      title,
+      ...(projectId ? { projectId } : {}),
+      ...(areaId ? { areaId } : focusAreaId ? { areaId: focusAreaId } : {}),
+    });
   }
 
   return (

--- a/packages/client/src/components/tasks/TaskRow.tsx
+++ b/packages/client/src/components/tasks/TaskRow.tsx
@@ -11,6 +11,7 @@ export interface TaskRowTask {
   dueDate?: string | null;
   listId?: string | null;
   areaId?: string | null;
+  projectId?: string | null;
   source?: string | null;
   externalKey?: string | null;
   externalUrl?: string | null;
@@ -90,9 +91,17 @@ const TaskRow = forwardRef<HTMLDivElement, TaskRowProps>(function TaskRow(
         <p className={cn('text-body-medium text-foreground truncate', isDone && 'line-through text-muted-foreground')}>
           {task.title}
         </p>
-        {dueInfo && (
-          <span className={cn('text-caption', dueInfo.color)}>{dueInfo.label}</span>
-        )}
+        <div className="flex items-center gap-2">
+          {dueInfo && (
+            <span className={cn('text-caption', dueInfo.color)}>{dueInfo.label}</span>
+          )}
+          {!task.projectId && !isDone && (
+            <span className="text-[11px] text-muted-foreground/50">No project</span>
+          )}
+          {!task.areaId && !isDone && (
+            <span className="text-[11px] text-muted-foreground/50">No area</span>
+          )}
+        </div>
       </div>
 
       <div className="flex items-center gap-2">

--- a/packages/client/src/components/tasks/TaskSidebar.tsx
+++ b/packages/client/src/components/tasks/TaskSidebar.tsx
@@ -4,21 +4,24 @@ import { trpc } from '@/lib/trpc';
 import {
   Inbox, CalendarDays, CalendarClock, ListChecks,
   ChevronRight, Plus, FolderOpen, MapPin, Layers,
-  Crosshair, RefreshCw,
+  Crosshair, RefreshCw, CircleOff,
 } from 'lucide-react';
 
 type ViewKey = 'inbox' | 'today' | 'upcoming' | 'all';
+type SpecialFilter = 'noProject' | 'noArea';
 
 interface TaskSidebarProps {
   activeView: ViewKey | null;
   activeListId: string | null;
   activeAreaId: string | null;
   activeProjectId: string | null;
+  activeSpecialFilter: SpecialFilter | null;
   focusAreaId: string | null;
   onViewChange: (view: ViewKey) => void;
   onListSelect: (listId: string) => void;
   onAreaSelect: (areaId: string) => void;
   onProjectSelect: (projectId: string) => void;
+  onSpecialFilter: (filter: SpecialFilter) => void;
   onFocusArea: (areaId: string | null) => void;
 }
 
@@ -30,8 +33,8 @@ const smartViews = [
 ];
 
 export default function TaskSidebar({
-  activeView, activeListId, activeAreaId, activeProjectId, focusAreaId,
-  onViewChange, onListSelect, onAreaSelect, onProjectSelect, onFocusArea,
+  activeView, activeListId, activeAreaId, activeProjectId, activeSpecialFilter, focusAreaId,
+  onViewChange, onListSelect, onAreaSelect, onProjectSelect, onSpecialFilter, onFocusArea,
 }: TaskSidebarProps) {
   const { data: areas = [] } = trpc.tasks.areas.list.useQuery();
   const { data: lists = [] } = trpc.tasks.lists.list.useQuery();
@@ -120,6 +123,22 @@ export default function TaskSidebar({
           >
             <view.icon className="h-4 w-4 flex-shrink-0" />
             <span>{view.label}</span>
+          </button>
+        ))}
+        {/* Unassigned filters */}
+        {(['noProject', 'noArea'] as const).map((key) => (
+          <button
+            key={key}
+            onClick={() => onSpecialFilter(key)}
+            className={cn(
+              'flex items-center gap-2.5 w-full px-2.5 py-1.5 rounded-md text-body transition-colors duration-150',
+              activeSpecialFilter === key
+                ? 'bg-primary/15 text-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-surface-overlay',
+            )}
+          >
+            <CircleOff className="h-4 w-4 flex-shrink-0" />
+            <span>{key === 'noProject' ? 'No Project' : 'No Area'}</span>
           </button>
         ))}
       </div>

--- a/packages/client/src/pages/TasksPage.tsx
+++ b/packages/client/src/pages/TasksPage.tsx
@@ -9,12 +9,14 @@ import QuickAdd, { type QuickAddHandle } from '@/components/tasks/QuickAdd';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 
 type ViewKey = 'inbox' | 'today' | 'upcoming' | 'all';
+type SpecialFilter = 'noProject' | 'noArea';
 
 export default function TasksPage() {
   const [activeView, setActiveView] = useState<ViewKey>('inbox');
   const [activeListId, setActiveListId] = useState<string | null>(null);
   const [activeAreaId, setActiveAreaId] = useState<string | null>(null);
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const [activeSpecialFilter, setActiveSpecialFilter] = useState<SpecialFilter | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [showCompleted, setShowCompleted] = useState(false);
   const [focusAreaId, setFocusAreaId] = useState<string | null>(
@@ -38,7 +40,10 @@ export default function TasksPage() {
 
   // Build filter based on what's selected
   const filter: Record<string, any> = {};
-  if (activeListId) {
+  if (activeSpecialFilter) {
+    if (activeSpecialFilter === 'noProject') filter.noProject = true;
+    if (activeSpecialFilter === 'noArea') filter.noArea = true;
+  } else if (activeListId) {
     filter.listId = activeListId;
   } else if (activeProjectId) {
     filter.projectId = activeProjectId;
@@ -65,29 +70,36 @@ export default function TasksPage() {
   const activeTasks = tasks.filter((t: any) => !['done', 'cancelled'].includes(t.status));
   const doneTasks = tasks.filter((t: any) => t.status === 'done');
 
-  function handleViewChange(view: ViewKey) {
-    setActiveView(view);
+  function clearSelection() {
     setActiveListId(null);
     setActiveAreaId(null);
     setActiveProjectId(null);
+    setActiveSpecialFilter(null);
+  }
+
+  function handleViewChange(view: ViewKey) {
+    clearSelection();
+    setActiveView(view);
   }
 
   function handleListSelect(listId: string) {
+    clearSelection();
     setActiveListId(listId);
-    setActiveAreaId(null);
-    setActiveProjectId(null);
   }
 
   function handleAreaSelect(areaId: string) {
+    clearSelection();
     setActiveAreaId(areaId);
-    setActiveListId(null);
-    setActiveProjectId(null);
   }
 
   function handleProjectSelect(projectId: string) {
+    clearSelection();
     setActiveProjectId(projectId);
-    setActiveListId(null);
-    setActiveAreaId(null);
+  }
+
+  function handleSpecialFilter(f: SpecialFilter) {
+    clearSelection();
+    setActiveSpecialFilter(f);
   }
 
   // Determine header title
@@ -99,15 +111,17 @@ export default function TasksPage() {
   return (
     <div className="flex h-full">
       <TaskSidebar
-        activeView={!activeListId && !activeAreaId && !activeProjectId ? activeView : null}
+        activeView={!activeListId && !activeAreaId && !activeProjectId && !activeSpecialFilter ? activeView : null}
         activeListId={activeListId}
         activeAreaId={activeAreaId}
         activeProjectId={activeProjectId}
+        activeSpecialFilter={activeSpecialFilter}
         focusAreaId={focusAreaId}
         onViewChange={handleViewChange}
         onListSelect={handleListSelect}
         onAreaSelect={handleAreaSelect}
         onProjectSelect={handleProjectSelect}
+        onSpecialFilter={handleSpecialFilter}
         onFocusArea={handleFocusArea}
       />
 
@@ -115,7 +129,12 @@ export default function TasksPage() {
         {/* Task list */}
         <div className="flex-1 overflow-y-auto p-6">
           <div className="max-w-2xl mx-auto space-y-3">
-            <QuickAdd ref={quickAddRef} focusAreaId={focusAreaId} />
+            <QuickAdd
+              ref={quickAddRef}
+              focusAreaId={focusAreaId}
+              projectId={activeProjectId}
+              areaId={activeAreaId}
+            />
 
             {isLoading ? (
               <div className="space-y-3 mt-4">

--- a/packages/server/src/services/task-repository.ts
+++ b/packages/server/src/services/task-repository.ts
@@ -45,6 +45,14 @@ export class TaskRepository {
       conditions.push(lte(taskItems.dueDate, weekFromNow));
     }
 
+    if (filter.noProject) {
+      conditions.push(isNull(taskItems.projectId));
+    }
+
+    if (filter.noArea) {
+      conditions.push(isNull(taskItems.areaId));
+    }
+
     if (filter.focusAreaId) {
       const listIdsInArea = this.db
         .select({ id: taskLists.id })

--- a/packages/shared/src/schemas/tasks.ts
+++ b/packages/shared/src/schemas/tasks.ts
@@ -140,6 +140,8 @@ export const TaskFilter = z.object({
   projectId: z.string().uuid().optional(),
   status: TaskStatus.optional(),
   focusAreaId: z.string().uuid().optional(),
+  noProject: z.boolean().optional(),
+  noArea: z.boolean().optional(),
 });
 export type TaskFilter = z.infer<typeof TaskFilter>;
 


### PR DESCRIPTION
## Summary
- "No Project" and "No Area" filter buttons in the sidebar smart views section (Closes #53)
- Tasks without a project or area show subtle "No project" / "No area" labels in the task row
- Quick add auto-assigns `projectId` and `areaId` based on what's currently selected in the sidebar
- New `noProject` and `noArea` boolean flags on `TaskFilter` schema, handled server-side with `isNull` conditions

## Test plan
- [ ] Click "No Project" in sidebar — shows only tasks without a project
- [ ] Click "No Area" in sidebar — shows only tasks without an area
- [ ] Task rows for unassigned tasks show "No project" / "No area" labels
- [ ] Quick add while viewing a project auto-assigns tasks to that project
- [ ] Quick add while viewing an area auto-assigns tasks to that area
- [ ] Switching between views/filters clears the previous selection
- [ ] Focus mode still works correctly with the new filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)