### PR TITLE
Feature: tag management UI

### DIFF
--- a/packages/client/src/components/tasks/TagPicker.test.tsx
+++ b/packages/client/src/components/tasks/TagPicker.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+const mockTags = [
+  { id: 'tag-1', name: 'Work', color: 'blue' },
+  { id: 'tag-2', name: 'Personal', color: 'green' },
+  { id: 'tag-3', name: 'Urgent', color: 'rose' },
+];
+
+const createMutateFn = vi.fn();
+const deleteMutateFn = vi.fn();
+
+vi.mock('@/lib/trpc', () => ({
+  trpc: {
+    tasks: {
+      tags: {
+        list: { useQuery: () => ({ data: mockTags }) },
+        create: {
+          useMutation: (opts: any) => {
+            createMutateFn.mockImplementation((input: any) => {
+              opts?.onSuccess?.({ id: 'new-tag', ...input });
+            });
+            return { mutate: createMutateFn };
+          },
+        },
+        delete: {
+          useMutation: () => ({ mutate: deleteMutateFn }),
+        },
+      },
+    },
+    useUtils: () => ({
+      tasks: {
+        tags: { list: { invalidate: vi.fn() } },
+      },
+    }),
+  },
+}));
+
+import TagPicker from './TagPicker';
+
+describe('TagPicker', () => {
+  it('renders selected tags as badges', () => {
+    render(<TagPicker tagIds={['tag-1']} onChange={vi.fn()} />);
+    expect(screen.getByText('Work')).toBeInTheDocument();
+  });
+
+  it('renders unselected tags as toggleable buttons', () => {
+    render(<TagPicker tagIds={['tag-1']} onChange={vi.fn()} />);
+    // tag-2 and tag-3 should be available to add
+    expect(screen.getByText('Personal')).toBeInTheDocument();
+    expect(screen.getByText('Urgent')).toBeInTheDocument();
+  });
+
+  it('calls onChange when toggling a tag on', async () => {
+    const onChange = vi.fn();
+    render(<TagPicker tagIds={['tag-1']} onChange={onChange} />);
+    await userEvent.click(screen.getByText('Personal'));
+    expect(onChange).toHaveBeenCalledWith(['tag-1', 'tag-2']);
+  });
+
+  it('calls onChange when removing a selected tag', async () => {
+    const onChange = vi.fn();
+    render(<TagPicker tagIds={['tag-1', 'tag-2']} onChange={onChange} />);
+    // The X button next to "Work"
+    const removeButtons = screen.getAllByRole('button');
+    // Find the X button inside the Work badge
+    const workBadge = screen.getByText('Work').closest('span');
+    const removeBtn = workBadge?.querySelector('button');
+    if (removeBtn) await userEvent.click(removeBtn);
+    expect(onChange).toHaveBeenCalledWith(['tag-2']);
+  });
+
+  it('shows "New" button to create tags', () => {
+    render(<TagPicker tagIds={[]} onChange={vi.fn()} />);
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('shows create input when New is clicked', async () => {
+    render(<TagPicker tagIds={[]} onChange={vi.fn()} />);
+    await userEvent.click(screen.getByText('New'));
+    expect(screen.getByPlaceholderText('Tag name...')).toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/tasks/TagPicker.tsx
+++ b/packages/client/src/components/tasks/TagPicker.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { X, Plus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { trpc } from '@/lib/trpc';
+
+const TAG_COLORS = [
+  { value: 'blue', bg: 'bg-blue-500/20', text: 'text-blue-400', dot: 'bg-blue-400' },
+  { value: 'green', bg: 'bg-green-500/20', text: 'text-green-400', dot: 'bg-green-400' },
+  { value: 'purple', bg: 'bg-purple-500/20', text: 'text-purple-400', dot: 'bg-purple-400' },
+  { value: 'amber', bg: 'bg-amber-500/20', text: 'text-amber-400', dot: 'bg-amber-400' },
+  { value: 'rose', bg: 'bg-rose-500/20', text: 'text-rose-400', dot: 'bg-rose-400' },
+  { value: 'cyan', bg: 'bg-cyan-500/20', text: 'text-cyan-400', dot: 'bg-cyan-400' },
+];
+
+export function getTagColor(color: string | null | undefined) {
+  return TAG_COLORS.find((c) => c.value === color) ?? { value: 'default', bg: 'bg-muted', text: 'text-muted-foreground', dot: 'bg-muted-foreground' };
+}
+
+interface TagPickerProps {
+  tagIds: string[];
+  onChange: (tagIds: string[]) => void;
+}
+
+export default function TagPicker({ tagIds, onChange }: TagPickerProps) {
+  const { data: allTags = [] } = trpc.tasks.tags.list.useQuery();
+  const utils = trpc.useUtils();
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTagName, setNewTagName] = useState('');
+  const [newTagColor, setNewTagColor] = useState('blue');
+
+  const createTag = trpc.tasks.tags.create.useMutation({
+    onSuccess: (tag) => {
+      utils.tasks.tags.list.invalidate();
+      onChange([...tagIds, tag.id]);
+      setNewTagName('');
+      setShowCreate(false);
+    },
+  });
+
+  function toggleTag(tagId: string) {
+    if (tagIds.includes(tagId)) {
+      onChange(tagIds.filter((id) => id !== tagId));
+    } else {
+      onChange([...tagIds, tagId]);
+    }
+  }
+
+  function handleCreate() {
+    const name = newTagName.trim();
+    if (!name) return;
+    createTag.mutate({ name, color: newTagColor });
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Selected tags */}
+      {tagIds.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {tagIds.map((id) => {
+            const tag = allTags.find((t: any) => t.id === id);
+            if (!tag) return null;
+            const color = getTagColor(tag.color);
+            return (
+              <span
+                key={id}
+                className={cn('inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium', color.bg, color.text)}
+              >
+                {tag.name}
+                <button
+                  onClick={() => toggleTag(id)}
+                  className="hover:opacity-70 transition-opacity"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Available tags */}
+      <div className="flex flex-wrap gap-1">
+        {allTags
+          .filter((t: any) => !tagIds.includes(t.id))
+          .map((tag: any) => {
+            const color = getTagColor(tag.color);
+            return (
+              <button
+                key={tag.id}
+                onClick={() => toggleTag(tag.id)}
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] transition-colors',
+                  'text-muted-foreground hover:text-foreground border border-border hover:border-foreground/20',
+                )}
+              >
+                <div className={cn('w-1.5 h-1.5 rounded-full', color.dot)} />
+                {tag.name}
+              </button>
+            );
+          })}
+        <button
+          onClick={() => setShowCreate(true)}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] text-muted-foreground hover:text-foreground border border-dashed border-border hover:border-foreground/20 transition-colors"
+        >
+          <Plus className="h-3 w-3" />
+          New
+        </button>
+      </div>
+
+      {/* Create new tag inline */}
+      {showCreate && (
+        <div className="flex items-center gap-2">
+          <input
+            autoFocus
+            value={newTagName}
+            onChange={(e) => setNewTagName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleCreate();
+              if (e.key === 'Escape') { setShowCreate(false); setNewTagName(''); }
+            }}
+            placeholder="Tag name..."
+            className="flex-1 bg-surface-raised text-body text-foreground placeholder:text-muted-foreground/50 px-2 py-1 rounded border border-border focus:outline-none focus:border-primary/50"
+          />
+          <div className="flex gap-1">
+            {TAG_COLORS.map((c) => (
+              <button
+                key={c.value}
+                onClick={() => setNewTagColor(c.value)}
+                className={cn('w-4 h-4 rounded-full', c.dot, newTagColor === c.value && 'ring-2 ring-foreground ring-offset-1 ring-offset-surface-root')}
+              />
+            ))}
+          </div>
+          <button
+            onClick={() => { setShowCreate(false); setNewTagName(''); }}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/tasks/TaskDetail.tsx
+++ b/packages/client/src/components/tasks/TaskDetail.tsx
@@ -6,6 +6,7 @@ import TaskCheckbox from './TaskCheckbox';
 import MarkdownNotes from './MarkdownNotes';
 import TaskChecklist from './TaskChecklist';
 import { DatePicker } from '@/components/ui/date-picker';
+import TagPicker from './TagPicker';
 
 interface TaskDetailProps {
   taskId: string;
@@ -352,6 +353,15 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
               ))}
             </select>
           </div>
+        </div>
+
+        {/* Tags */}
+        <div className="pt-2 border-t border-border">
+          <span className="text-overline text-muted-foreground uppercase tracking-wider mb-2 block">Tags</span>
+          <TagPicker
+            tagIds={task.tagIds ?? []}
+            onChange={(tagIds) => save({ tagIds })}
+          />
         </div>
 
         {/* Checklist */}

--- a/packages/client/src/components/tasks/TaskSidebar.tsx
+++ b/packages/client/src/components/tasks/TaskSidebar.tsx
@@ -4,7 +4,7 @@ import { trpc } from '@/lib/trpc';
 import {
   Inbox, CalendarDays, CalendarClock, ListChecks,
   ChevronRight, Plus, FolderOpen, MapPin, Layers,
-  Crosshair, RefreshCw,
+  Crosshair, RefreshCw, Tag, X,
 } from 'lucide-react';
 
 type ViewKey = 'inbox' | 'today' | 'upcoming' | 'all';
@@ -48,6 +48,16 @@ export default function TaskSidebar({
     onSuccess: () => utils.tasks.projects.list.invalidate(),
   });
 
+  const { data: tags = [] } = trpc.tasks.tags.list.useQuery();
+  const createTag = trpc.tasks.tags.create.useMutation({
+    onSuccess: () => utils.tasks.tags.list.invalidate(),
+  });
+  const deleteTag = trpc.tasks.tags.delete.useMutation({
+    onSuccess: () => utils.tasks.tags.list.invalidate(),
+  });
+
+  const [showNewTag, setShowNewTag] = useState(false);
+  const [newTagName, setNewTagName] = useState('');
   const [newAreaName, setNewAreaName] = useState('');
   const [showNewArea, setShowNewArea] = useState(false);
   const [newListAreaId, setNewListAreaId] = useState<string | null>(null);
@@ -346,6 +356,59 @@ export default function TaskSidebar({
             ))}
           </>
         )}
+      </div>
+
+      <div className="mx-2 my-2 border-t border-border" />
+
+      {/* Tags */}
+      <div className="p-2 space-y-1">
+        <div className="flex items-center justify-between px-2.5 mb-1">
+          <span className="text-overline text-muted-foreground uppercase tracking-wider">Tags</span>
+          <button
+            onClick={() => setShowNewTag(true)}
+            className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        {showNewTag && (
+          <div className="px-2.5">
+            <input
+              autoFocus
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  const name = newTagName.trim();
+                  if (name) createTag.mutate({ name });
+                  setNewTagName('');
+                  setShowNewTag(false);
+                }
+                if (e.key === 'Escape') { setShowNewTag(false); setNewTagName(''); }
+              }}
+              onBlur={() => { setShowNewTag(false); setNewTagName(''); }}
+              placeholder="Tag name..."
+              className="w-full bg-surface-raised text-body text-foreground placeholder:text-muted-foreground/50 px-2 py-1 rounded border border-border focus:outline-none focus:border-primary/50"
+            />
+          </div>
+        )}
+
+        {tags.map((tag: any) => (
+          <div
+            key={tag.id}
+            className="group/tag flex items-center gap-2 px-2.5 py-1.5 rounded-md text-body text-muted-foreground"
+          >
+            <Tag className="h-3.5 w-3.5 flex-shrink-0" />
+            <span className="truncate flex-1">{tag.name}</span>
+            <button
+              onClick={() => deleteTag.mutate({ id: tag.id })}
+              className="p-0.5 rounded opacity-0 group-hover/tag:opacity-100 text-muted-foreground hover:text-status-error transition-all"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds **TagPicker** component — multi-select toggle with color-coded dots, inline tag creation with color picker
- Adds **Tags section** to sidebar — view all tags, create new ones, delete with hover X button
- Integrates TagPicker into **TaskDetail** panel for assigning/removing tags on tasks
- Backend already existed (tag CRUD + task-tag association via tRPC) — this is purely UI

## Test plan
- [x] `pnpm build` passes
- [x] All 121 tests pass (6 new TagPicker tests)
- [ ] Manual: open task detail, add/remove tags via picker
- [ ] Manual: create new tag inline with color selection
- [ ] Manual: sidebar shows tags section with create/delete
- [ ] Manual: tags persist across page navigation

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)