### PR TITLE
Soft-delete with confirmation dialogs

### DIFF
--- a/drizzle/0004_broad_shriek.sql
+++ b/drizzle/0004_broad_shriek.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "task_areas" ADD COLUMN "archived_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "task_items" ADD COLUMN "archived_at" timestamp with time zone;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,845 @@
+{
+  "id": "cf96e4f9-6718-419a-bb33-ef138c6c9f2a",
+  "prevId": "782c903b-e8b5-4bfe-8095-cb56d2eb16df",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_areas": {
+      "name": "task_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_checklist": {
+      "name": "task_checklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_checklist_task_id_task_items_id_fk": {
+          "name": "task_checklist_task_id_task_items_id_fk",
+          "tableFrom": "task_checklist",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_item_tags": {
+      "name": "task_item_tags",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_item_tags_task_id_task_items_id_fk": {
+          "name": "task_item_tags_task_id_task_items_id_fk",
+          "tableFrom": "task_item_tags",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_item_tags_tag_id_task_tags_id_fk": {
+          "name": "task_item_tags_tag_id_task_tags_id_fk",
+          "tableFrom": "task_item_tags",
+          "tableTo": "task_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_item_tags_task_id_tag_id_pk": {
+          "name": "task_item_tags_task_id_tag_id_pk",
+          "columns": [
+            "task_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_time": {
+          "name": "due_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_minutes": {
+          "name": "estimate_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_spent_minutes": {
+          "name": "time_spent_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_parent_id": {
+          "name": "recurrence_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_items_list_id_task_lists_id_fk": {
+          "name": "task_items_list_id_task_lists_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_area_id_task_areas_id_fk": {
+          "name": "task_items_area_id_task_areas_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_project_id_task_projects_id_fk": {
+          "name": "task_items_project_id_task_projects_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_external_key_unique": {
+          "name": "task_items_external_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_lists_area_id_task_areas_id_fk": {
+          "name": "task_lists_area_id_task_areas_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_projects": {
+      "name": "task_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_projects_area_id_task_areas_id_fk": {
+          "name": "task_projects_area_id_task_areas_id_fk",
+          "tableFrom": "task_projects",
+          "tableTo": "task_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_tags": {
+      "name": "task_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_tags_name_unique": {
+          "name": "task_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jira_sync_log": {
+      "name": "jira_sync_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jira_sync_log_webhook_id_unique": {
+          "name": "jira_sync_log_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1771114735989,
       "tag": "0003_overconfident_sunspot",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1771126822777,
+      "tag": "0004_broad_shriek",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/client/src/components/tasks/ProjectHeader.tsx
+++ b/packages/client/src/components/tasks/ProjectHeader.tsx
@@ -3,6 +3,7 @@ import { Layers, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/lib/trpc';
 import { DatePicker } from '@/components/ui/date-picker';
+import ConfirmDialog from '@/components/ui/confirm-dialog';
 
 const statusOptions = [
   { value: 'active', label: 'Active', color: 'text-status-info' },
@@ -26,6 +27,7 @@ export default function ProjectHeader({ projectId, onDeleted }: ProjectHeaderPro
   const [status, setStatus] = useState('active');
   const [startDate, setStartDate] = useState('');
   const [dueDate, setDueDate] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     if (project) {
@@ -85,9 +87,9 @@ export default function ProjectHeader({ projectId, onDeleted }: ProjectHeaderPro
           />
         </div>
         <button
-          onClick={() => deleteMutation.mutate({ id: projectId })}
+          onClick={() => setShowDeleteConfirm(true)}
           className="p-1.5 rounded-md text-muted-foreground hover:text-status-error hover:bg-status-error/10 transition-colors"
-          title="Delete project"
+          title="Archive project"
         >
           <Trash2 className="h-4 w-4" />
         </button>
@@ -144,6 +146,14 @@ export default function ProjectHeader({ projectId, onDeleted }: ProjectHeaderPro
       )}
 
       <div className="border-b border-border" />
+
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        title="Archive this project?"
+        description={`"${project.name}" and its tasks will be archived. Tasks won't be deleted but will be hidden from views.`}
+        onConfirm={() => { setShowDeleteConfirm(false); deleteMutation.mutate({ id: projectId }); }}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
     </div>
   );
 }

--- a/packages/client/src/components/tasks/TaskDetail.tsx
+++ b/packages/client/src/components/tasks/TaskDetail.tsx
@@ -7,6 +7,7 @@ import MarkdownNotes from './MarkdownNotes';
 import TaskChecklist from './TaskChecklist';
 import { DatePicker } from '@/components/ui/date-picker';
 import TagPicker from './TagPicker';
+import ConfirmDialog from '@/components/ui/confirm-dialog';
 
 interface TaskDetailProps {
   taskId: string;
@@ -45,6 +46,7 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
   const [estimateMinutes, setEstimateMinutes] = useState<number | null>(null);
   const [projectId, setProjectId] = useState<string | null>(null);
   const [recurrenceRule, setRecurrenceRule] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     if (task) {
@@ -120,9 +122,9 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
         </div>
         <div className="flex items-center gap-1">
           <button
-            onClick={() => deleteMutation.mutate({ id: taskId })}
+            onClick={() => setShowDeleteConfirm(true)}
             className="p-1.5 rounded-md text-muted-foreground hover:text-status-error hover:bg-status-error/10 transition-colors"
-            title="Delete task"
+            title="Archive task"
           >
             <Trash2 className="h-4 w-4" />
           </button>
@@ -323,6 +325,14 @@ export default function TaskDetail({ taskId, onClose }: TaskDetailProps) {
         {/* Checklist */}
         <TaskChecklist taskId={taskId} checklist={checklist} />
       </div>
+
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        title="Archive this task?"
+        description="This task will be archived and hidden from all views. It can be restored later."
+        onConfirm={() => { setShowDeleteConfirm(false); deleteMutation.mutate({ id: taskId }); }}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
     </div>
   );
 }

--- a/packages/client/src/components/tasks/TaskSidebar.tsx
+++ b/packages/client/src/components/tasks/TaskSidebar.tsx
@@ -4,8 +4,9 @@ import { trpc } from '@/lib/trpc';
 import {
   Inbox, CalendarDays, CalendarClock, ListChecks,
   ChevronRight, Plus, MapPin, Layers, CircleOff,
-  Crosshair, RefreshCw, Tag, X,
+  Crosshair, RefreshCw, Tag, X, Trash2,
 } from 'lucide-react';
+import ConfirmDialog from '@/components/ui/confirm-dialog';
 
 type ViewKey = 'inbox' | 'today' | 'upcoming' | 'all';
 
@@ -105,6 +106,14 @@ export default function TaskSidebar({
     onSuccess: () => utils.tasks.tags.list.invalidate(),
   });
 
+  const deleteArea = trpc.tasks.areas.delete.useMutation({
+    onSuccess: () => {
+      utils.tasks.areas.list.invalidate();
+      utils.tasks.projects.list.invalidate();
+      utils.tasks.list.invalidate();
+    },
+  });
+
   const [showNewTag, setShowNewTag] = useState(false);
   const [newTagName, setNewTagName] = useState('');
   const [newAreaName, setNewAreaName] = useState('');
@@ -112,6 +121,7 @@ export default function TaskSidebar({
   const [newProjectName, setNewProjectName] = useState('');
   const [showNewProject, setShowNewProject] = useState(false);
   const [expandedAreas, setExpandedAreas] = useState<Set<string>>(new Set());
+  const [confirmDelete, setConfirmDelete] = useState<{ type: 'area' | 'tag'; id: string; name: string } | null>(null);
 
   const { data: jiraStatus } = trpc.jira.status.useQuery(undefined, {
     retry: false,
@@ -326,11 +336,18 @@ export default function TaskSidebar({
                     'p-1 rounded transition-colors',
                     focusAreaId === area.id
                       ? 'text-primary'
-                      : 'text-muted-foreground/0 hover:text-muted-foreground',
+                      : 'text-muted-foreground/0 group-hover/area:text-muted-foreground',
                   )}
                   title={focusAreaId === area.id ? 'Clear focus' : 'Focus on this area'}
                 >
                   <Crosshair className="h-3 w-3" />
+                </button>
+                <button
+                  onClick={() => setConfirmDelete({ type: 'area', id: area.id, name: area.name })}
+                  className="p-1 rounded opacity-0 group-hover/area:opacity-100 text-muted-foreground hover:text-status-error transition-all"
+                  title="Archive area"
+                >
+                  <Trash2 className="h-3 w-3" />
                 </button>
               </div>
 
@@ -396,7 +413,7 @@ export default function TaskSidebar({
             <Tag className="h-3.5 w-3.5 flex-shrink-0" />
             <span className="truncate flex-1">{tag.name}</span>
             <button
-              onClick={() => deleteTag.mutate({ id: tag.id })}
+              onClick={() => setConfirmDelete({ type: 'tag', id: tag.id, name: tag.name })}
               className="p-0.5 rounded opacity-0 group-hover/tag:opacity-100 text-muted-foreground hover:text-status-error transition-all"
             >
               <X className="h-3 w-3" />
@@ -404,6 +421,23 @@ export default function TaskSidebar({
           </div>
         ))}
       </div>
+
+      <ConfirmDialog
+        open={!!confirmDelete}
+        title={confirmDelete?.type === 'area' ? 'Archive this area?' : 'Delete this tag?'}
+        description={
+          confirmDelete?.type === 'area'
+            ? `"${confirmDelete?.name}" will be archived. Its projects and tasks will remain but won't be grouped under this area.`
+            : `"${confirmDelete?.name}" will be removed from all tasks.`
+        }
+        confirmLabel={confirmDelete?.type === 'area' ? 'Archive' : 'Delete'}
+        onConfirm={() => {
+          if (confirmDelete?.type === 'area') deleteArea.mutate({ id: confirmDelete.id });
+          else if (confirmDelete?.type === 'tag') deleteTag.mutate({ id: confirmDelete.id });
+          setConfirmDelete(null);
+        }}
+        onCancel={() => setConfirmDelete(null)}
+      />
     </div>
   );
 }

--- a/packages/client/src/components/ui/confirm-dialog.tsx
+++ b/packages/client/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  open, title, description, confirmLabel = 'Archive', onConfirm, onCancel,
+}: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel();
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onCancel} />
+      <div className="relative bg-surface-raised border border-border rounded-lg shadow-lg max-w-sm w-full mx-4 p-5 space-y-4">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-full bg-status-urgency-high/10">
+            <AlertTriangle className="h-5 w-5 text-status-urgency-high" />
+          </div>
+          <div>
+            <h3 className="text-body-medium text-foreground font-semibold">{title}</h3>
+            <p className="text-caption text-muted-foreground mt-1">{description}</p>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded-md text-body text-muted-foreground hover:text-foreground hover:bg-surface-overlay transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-3 py-1.5 rounded-md text-body text-white bg-status-urgency-high hover:bg-status-urgency-high/80 transition-colors"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/ui/confirm-dialog.tsx
+++ b/packages/client/src/components/ui/confirm-dialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { AlertTriangle } from 'lucide-react';
 
 interface ConfirmDialogProps {
@@ -30,7 +31,7 @@ export default function ConfirmDialog({
 
   if (!open) return null;
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/60" onClick={onCancel} />
       <div className="relative bg-surface-raised border border-border rounded-lg shadow-lg max-w-sm w-full mx-4 p-5 space-y-4">
@@ -59,6 +60,7 @@ export default function ConfirmDialog({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/server/src/db/schema/tasks.ts
+++ b/packages/server/src/db/schema/tasks.ts
@@ -6,6 +6,7 @@ export const taskAreas = pgTable('task_areas', {
   icon: text('icon'),
   color: text('color'),
   sortOrder: integer('sort_order').notNull().default(0),
+  archivedAt: timestamp('archived_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
@@ -60,6 +61,7 @@ export const taskItems = pgTable('task_items', {
   sortOrder: integer('sort_order').notNull().default(0),
   recurrenceRule: text('recurrence_rule'),
   recurrenceParentId: uuid('recurrence_parent_id'),
+  archivedAt: timestamp('archived_at', { withTimezone: true }),
   source: text('source', { enum: ['local', 'jira'] }).notNull().default('local'),
   externalKey: text('external_key').unique(),
   externalUrl: text('external_url'),

--- a/packages/server/src/db/schema/tasks.ts
+++ b/packages/server/src/db/schema/tasks.ts
@@ -11,17 +11,6 @@ export const taskAreas = pgTable('task_areas', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
-export const taskLists = pgTable('task_lists', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  name: text('name').notNull(),
-  areaId: uuid('area_id').references(() => taskAreas.id, { onDelete: 'set null' }),
-  icon: text('icon'),
-  color: text('color'),
-  sortOrder: integer('sort_order').notNull().default(0),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
-});
-
 export const taskProjects = pgTable('task_projects', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: text('name').notNull(),
@@ -47,8 +36,6 @@ export const taskItems = pgTable('task_items', {
   id: uuid('id').primaryKey().defaultRandom(),
   title: text('title').notNull(),
   notes: text('notes'),
-  listId: uuid('list_id').references(() => taskLists.id, { onDelete: 'set null' }),
-  areaId: uuid('area_id').references(() => taskAreas.id, { onDelete: 'set null' }),
   projectId: uuid('project_id').references(() => taskProjects.id, { onDelete: 'set null' }),
   status: text('status', { enum: ['todo', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled'] }).notNull().default('todo'),
   priority: integer('priority').notNull().default(0),

--- a/packages/server/src/services/area-repository.ts
+++ b/packages/server/src/services/area-repository.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from 'inversify';
-import { eq, asc } from 'drizzle-orm';
+import { eq, asc, isNull } from 'drizzle-orm';
 import { SYMBOLS } from '../di/symbols.js';
 import { taskAreas } from '../db/schema/tasks.js';
 import type { Database } from '../db/drizzle.js';
@@ -9,7 +9,7 @@ export class AreaRepository {
   constructor(@inject(SYMBOLS.Database) private db: Database) {}
 
   async list() {
-    return this.db.select().from(taskAreas).orderBy(asc(taskAreas.sortOrder));
+    return this.db.select().from(taskAreas).where(isNull(taskAreas.archivedAt)).orderBy(asc(taskAreas.sortOrder));
   }
 
   async getById(id: string) {
@@ -32,6 +32,9 @@ export class AreaRepository {
   }
 
   async delete(id: string) {
-    await this.db.delete(taskAreas).where(eq(taskAreas.id, id));
+    await this.db
+      .update(taskAreas)
+      .set({ archivedAt: new Date(), updatedAt: new Date() })
+      .where(eq(taskAreas.id, id));
   }
 }

--- a/packages/server/src/services/project-repository.ts
+++ b/packages/server/src/services/project-repository.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from 'inversify';
-import { eq, asc } from 'drizzle-orm';
+import { eq, asc, ne } from 'drizzle-orm';
 import { SYMBOLS } from '../di/symbols.js';
 import { taskProjects } from '../db/schema/tasks.js';
 import type { Database } from '../db/drizzle.js';
@@ -9,7 +9,7 @@ export class ProjectRepository {
   constructor(@inject(SYMBOLS.Database) private db: Database) {}
 
   async list() {
-    return this.db.select().from(taskProjects).orderBy(asc(taskProjects.sortOrder));
+    return this.db.select().from(taskProjects).where(ne(taskProjects.status, 'archived')).orderBy(asc(taskProjects.sortOrder));
   }
 
   async getById(id: string) {
@@ -32,6 +32,9 @@ export class ProjectRepository {
   }
 
   async delete(id: string) {
-    await this.db.delete(taskProjects).where(eq(taskProjects.id, id));
+    await this.db
+      .update(taskProjects)
+      .set({ status: 'archived', updatedAt: new Date() })
+      .where(eq(taskProjects.id, id));
   }
 }

--- a/packages/server/src/services/task-repository.ts
+++ b/packages/server/src/services/task-repository.ts
@@ -10,7 +10,7 @@ export class TaskRepository {
   constructor(@inject(SYMBOLS.Database) private db: Database) {}
 
   async list(filter: TaskFilter) {
-    const conditions = []; // drizzle conditions
+    const conditions = [isNull(taskItems.archivedAt)];
 
     if (filter.status) {
       conditions.push(eq(taskItems.status, filter.status));
@@ -87,7 +87,10 @@ export class TaskRepository {
   }
 
   async delete(id: string) {
-    await this.db.delete(taskItems).where(eq(taskItems.id, id));
+    await this.db
+      .update(taskItems)
+      .set({ archivedAt: new Date(), updatedAt: new Date() })
+      .where(eq(taskItems.id, id));
   }
 
   async getTagIds(taskId: string) {


### PR DESCRIPTION
## Summary
- Converts all delete operations to soft-delete (archived_at timestamp for tasks/areas, archived status for projects)
- Adds reusable `ConfirmDialog` component with warning modal before any destructive action
- Adds area delete button (trash icon, visible on hover) to sidebar
- Filters archived records from all list queries so they're hidden but recoverable

## Test plan
- [ ] Delete a task from detail panel — confirm dialog appears, task disappears after confirming
- [ ] Delete a project from project header — confirm dialog appears, project archives
- [ ] Delete an area from sidebar — trash icon visible on hover, confirm dialog, area archives
- [ ] Delete a tag from sidebar — confirm dialog appears, tag removed
- [ ] Cancel any confirm dialog — no action taken
- [ ] Press Escape to dismiss confirm dialog
- [ ] All 121 existing tests pass

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)