### PR TITLE
Icon and color picker for projects and areas

### DIFF
--- a/packages/client/src/components/tasks/ProjectHeader.tsx
+++ b/packages/client/src/components/tasks/ProjectHeader.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Layers, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/lib/trpc';
 import { DatePicker } from '@/components/ui/date-picker';
 import ConfirmDialog from '@/components/ui/confirm-dialog';
+import IconColorPicker, { getIconComponent, getColorClass } from '@/components/ui/icon-color-picker';
 
 const statusOptions = [
   { value: 'active', label: 'Active', color: 'text-status-info' },
@@ -68,7 +69,15 @@ export default function ProjectHeader({ projectId, onDeleted }: ProjectHeaderPro
     <div className="mb-6 space-y-3">
       {/* Title row */}
       <div className="flex items-start gap-3">
-        <Layers className="h-5 w-5 text-muted-foreground mt-1 flex-shrink-0" />
+        <div className="mt-1">
+          <IconColorPicker
+            icon={project.icon ?? null}
+            color={project.color ?? null}
+            onChangeIcon={(icon) => save({ icon })}
+            onChangeColor={(color) => save({ color })}
+            size="md"
+          />
+        </div>
         <div className="flex-1 min-w-0">
           <input
             value={name}

--- a/packages/client/src/components/tasks/TaskSidebar.tsx
+++ b/packages/client/src/components/tasks/TaskSidebar.tsx
@@ -3,10 +3,11 @@ import { cn } from '@/lib/utils';
 import { trpc } from '@/lib/trpc';
 import {
   Inbox, CalendarDays, CalendarClock, ListChecks,
-  ChevronRight, Plus, MapPin, Layers, CircleOff,
+  ChevronRight, Plus, CircleOff,
   Crosshair, RefreshCw, Tag, X, Trash2,
 } from 'lucide-react';
 import ConfirmDialog from '@/components/ui/confirm-dialog';
+import { getIconComponent, getColorClass } from '@/components/ui/icon-color-picker';
 
 type ViewKey = 'inbox' | 'today' | 'upcoming' | 'all';
 
@@ -49,13 +50,15 @@ function ProjectDropButton({
   onDropTask,
   className: extraClassName,
 }: {
-  project: { id: string; name: string };
+  project: { id: string; name: string; icon?: string | null; color?: string | null };
   isActive: boolean;
   onClick: () => void;
   onDropTask?: (taskId: string, projectId: string) => void;
   className?: string;
 }) {
   const drop = useDropTarget((taskId) => onDropTask?.(taskId, project.id));
+  const Icon = getIconComponent(project.icon);
+  const colorClass = getColorClass(project.color);
   return (
     <button
       onClick={onClick}
@@ -69,7 +72,7 @@ function ProjectDropButton({
         extraClassName,
       )}
     >
-      <Layers className="h-3.5 w-3.5 flex-shrink-0" />
+      <Icon className={cn('h-3.5 w-3.5 flex-shrink-0', !isActive && colorClass)} />
       <span className="truncate">{project.name}</span>
     </button>
   );
@@ -327,7 +330,7 @@ export default function TaskSidebar({
                       : 'text-muted-foreground hover:text-foreground hover:bg-surface-overlay',
                   )}
                 >
-                  <MapPin className="h-3.5 w-3.5 flex-shrink-0" />
+                  {(() => { const AreaIcon = getIconComponent(area.icon); return <AreaIcon className={cn('h-3.5 w-3.5 flex-shrink-0', activeAreaId !== area.id && getColorClass(area.color))} />; })()}
                   <span className="truncate">{area.name}</span>
                 </button>
                 <button

--- a/packages/client/src/components/ui/icon-color-picker.tsx
+++ b/packages/client/src/components/ui/icon-color-picker.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '@/lib/utils';
+import {
+  Layers, MapPin, Briefcase, Code, Folder, Heart, Home,
+  BookOpen, Dumbbell, DollarSign, Music, Palette, Rocket,
+  Shield, Target, Wrench, Zap, Coffee, Globe, Lightbulb,
+  GraduationCap, Camera, Gamepad2, Plane, ShoppingCart,
+  type LucideIcon,
+} from 'lucide-react';
+
+export const ICON_OPTIONS: { value: string; icon: LucideIcon }[] = [
+  { value: 'layers', icon: Layers },
+  { value: 'map-pin', icon: MapPin },
+  { value: 'briefcase', icon: Briefcase },
+  { value: 'code', icon: Code },
+  { value: 'folder', icon: Folder },
+  { value: 'heart', icon: Heart },
+  { value: 'home', icon: Home },
+  { value: 'book-open', icon: BookOpen },
+  { value: 'dumbbell', icon: Dumbbell },
+  { value: 'dollar-sign', icon: DollarSign },
+  { value: 'music', icon: Music },
+  { value: 'palette', icon: Palette },
+  { value: 'rocket', icon: Rocket },
+  { value: 'shield', icon: Shield },
+  { value: 'target', icon: Target },
+  { value: 'wrench', icon: Wrench },
+  { value: 'zap', icon: Zap },
+  { value: 'coffee', icon: Coffee },
+  { value: 'globe', icon: Globe },
+  { value: 'lightbulb', icon: Lightbulb },
+  { value: 'graduation-cap', icon: GraduationCap },
+  { value: 'camera', icon: Camera },
+  { value: 'gamepad-2', icon: Gamepad2 },
+  { value: 'plane', icon: Plane },
+  { value: 'shopping-cart', icon: ShoppingCart },
+];
+
+export const COLOR_OPTIONS = [
+  { value: 'zinc', tw: 'text-zinc-400', bg: 'bg-zinc-400' },
+  { value: 'blue', tw: 'text-blue-400', bg: 'bg-blue-400' },
+  { value: 'green', tw: 'text-green-400', bg: 'bg-green-400' },
+  { value: 'purple', tw: 'text-purple-400', bg: 'bg-purple-400' },
+  { value: 'amber', tw: 'text-amber-400', bg: 'bg-amber-400' },
+  { value: 'rose', tw: 'text-rose-400', bg: 'bg-rose-400' },
+  { value: 'cyan', tw: 'text-cyan-400', bg: 'bg-cyan-400' },
+  { value: 'teal', tw: 'text-teal-400', bg: 'bg-teal-400' },
+  { value: 'indigo', tw: 'text-indigo-400', bg: 'bg-indigo-400' },
+  { value: 'orange', tw: 'text-orange-400', bg: 'bg-orange-400' },
+];
+
+export function getIconComponent(value: string | null | undefined): LucideIcon {
+  return ICON_OPTIONS.find((i) => i.value === value)?.icon ?? Layers;
+}
+
+export function getColorClass(value: string | null | undefined): string {
+  return COLOR_OPTIONS.find((c) => c.value === value)?.tw ?? 'text-muted-foreground';
+}
+
+interface IconColorPickerProps {
+  icon: string | null;
+  color: string | null;
+  onChangeIcon: (icon: string) => void;
+  onChangeColor: (color: string) => void;
+  /** Size of the trigger icon */
+  size?: 'sm' | 'md';
+}
+
+export default function IconColorPicker({
+  icon, color, onChangeIcon, onChangeColor, size = 'sm',
+}: IconColorPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  const Icon = getIconComponent(icon);
+  const colorClass = getColorClass(color);
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-5 w-5';
+
+  function handleOpen(e: React.MouseEvent) {
+    e.stopPropagation();
+    setAnchorRect(e.currentTarget.getBoundingClientRect());
+    setOpen(true);
+  }
+
+  return (
+    <>
+      <button
+        onClick={handleOpen}
+        className={cn('flex-shrink-0 rounded p-0.5 transition-colors hover:bg-surface-overlay', colorClass)}
+        title="Change icon & color"
+      >
+        <Icon className={iconSize} />
+      </button>
+
+      {open && anchorRect && createPortal(
+        <>
+          <div className="fixed inset-0 z-50" onClick={() => setOpen(false)} />
+          <div
+            className="fixed z-50 bg-surface-raised border border-border rounded-lg shadow-lg p-3 space-y-3 w-64"
+            style={{
+              top: anchorRect.bottom + 4,
+              left: Math.min(anchorRect.left, window.innerWidth - 272),
+            }}
+          >
+            {/* Colors */}
+            <div>
+              <span className="text-overline text-muted-foreground uppercase tracking-wider text-[10px]">Color</span>
+              <div className="flex flex-wrap gap-1.5 mt-1.5">
+                {COLOR_OPTIONS.map((c) => (
+                  <button
+                    key={c.value}
+                    onClick={() => onChangeColor(c.value)}
+                    className={cn(
+                      'w-5 h-5 rounded-full transition-all',
+                      c.bg,
+                      color === c.value && 'ring-2 ring-foreground ring-offset-1 ring-offset-surface-raised',
+                    )}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Icons */}
+            <div>
+              <span className="text-overline text-muted-foreground uppercase tracking-wider text-[10px]">Icon</span>
+              <div className="grid grid-cols-8 gap-1 mt-1.5">
+                {ICON_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => { onChangeIcon(opt.value); setOpen(false); }}
+                    className={cn(
+                      'p-1.5 rounded transition-colors',
+                      icon === opt.value
+                        ? 'bg-primary/15 text-foreground'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-surface-overlay',
+                    )}
+                  >
+                    <opt.icon className="h-3.5 w-3.5" />
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </>,
+        document.body,
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `IconColorPicker` component with 25 curated lucide icons and 10 theme-friendly colors
- Sidebar renders dynamic icons/colors for projects and areas (instead of hardcoded Layers/MapPin)
- Project header has a clickable icon that opens the picker popover to change icon and color
- Colors (zinc, blue, green, purple, amber, rose, cyan, teal, indigo, orange) chosen to complement the dark theme without conflicting with status colors

## Test plan
- [ ] Click a project icon in the project header — picker opens with color dots and icon grid
- [ ] Select a color — icon updates immediately, persists on refresh
- [ ] Select an icon — picker closes, icon updates in both header and sidebar
- [ ] Projects/areas with no icon/color set show defaults (Layers/MapPin in muted)
- [ ] All 121 tests pass

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)